### PR TITLE
add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.txt


### PR DESCRIPTION
requirements.txt is referenced from setup.py but isn't included in the sdist.  This makes it impossible to install hippybot without doing a checkout a full tree from the repository.  The current pypi package, for example, cannot be installed because of this:

Downloading/unpacking hippybot
  Downloading hippybot-1.0.0.tar.gz
  Running setup.py egg_info for package hippybot
    Traceback (most recent call last):
      File "<string>", line 14, in <module>
      File "/Users/orb/.virtualenvs/87c77f75-a81f-4421-81bd-2830697e4341/build/hippybot/setup.py", line 18, in <module>
        install_requires=open('requirements.txt').readlines(),
    IOError: [Errno 2] No such file or directory: 'requirements.txt'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 14, in <module>

  File "/Users/orb/.virtualenvs/87c77f75-a81f-4421-81bd-2830697e4341/build/hippybot/setup.py", line 18, in <module>

```
install_requires=open('requirements.txt').readlines(),
```

IOError: [Errno 2] No such file or directory: 'requirements.txt'

---

Command python setup.py egg_info failed with error code 1
Storing complete log in /Users/orb/.pip/pip.log
