### PR TITLE
Add the configuration option [plugin][load_path]

### DIFF
--- a/hippybot.conf.example
+++ b/hippybot.conf.example
@@ -5,9 +5,16 @@ nickname = Hippy Bot
 channels = Hippy Bot's Room
            test
            My Room
+# a list of plugins that should be loaded from a list of directories.
 [plugins]
-load = hippybot.plugins.rot13
-       hippybot.plugins.mexican_wave
+load = rot13
+       mexican_wave
+
+load_path = /absolute/path/plugins
+	hippybot/plugins
+	plugins
+	another/relative/path
+
 [hipchat]
 api_auth_token = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 respond_to_all = true


### PR DESCRIPTION
This option can be used to specify absolute and relative paths on which
the bot will looking for additional plugins.

The introduction of this feature will decreare the need for user to fork
this repo just to add some vertical/not-shareble plugins.
You can see some example scouting the repo network:
 https://github.com/1stvamp/hippybot/network

Signed-off-by: Claudio Mignanti <c.mignanti@gmail.com>